### PR TITLE
dev/0.2.6

### DIFF
--- a/llm_defender/base/protocol.py
+++ b/llm_defender/base/protocol.py
@@ -35,7 +35,6 @@ class LLMDefenderProtocol(bt.Synapse):
         title="Roles",
         description="An immutable list depicting the roles",
         allow_mutation=False,
-        regex=r"^(internal|external)$",
     )
 
     analyzer: typing.List[str] = pydantic.Field(
@@ -43,7 +42,6 @@ class LLMDefenderProtocol(bt.Synapse):
         title="analyzer",
         description="An immutable list depicting the analyzers to execute",
         allow_mutation=False,
-        regex=r"^(Prompt Injection)$",
     )
 
     def get_analyzers(self) -> list:

--- a/llm_defender/core/miners/miner.py
+++ b/llm_defender/core/miners/miner.py
@@ -116,7 +116,7 @@ class PromptInjectionMiner(BaseNeuron):
             return False
         
         whitelisted_hotkeys = [
-            "5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX" # sn14 mainnet test validator
+            "5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX" # sn14 dev team test validator
         ]
 
         if hotkey in whitelisted_hotkeys:

--- a/llm_defender/core/miners/miner.py
+++ b/llm_defender/core/miners/miner.py
@@ -41,6 +41,8 @@ class PromptInjectionMiner(BaseNeuron):
             self.miner_set_weights = False
         else:
             self.miner_set_weights = True
+        
+        self.validator_min_stake = parser.validator_min_stake
 
         self.chromadb_client = VectorEngine().initialize()
 
@@ -140,7 +142,7 @@ class PromptInjectionMiner(BaseNeuron):
 
         # Blacklist entities that have insufficient stake
         stake = float(self.metagraph.S[uid])
-        if stake <= 0.0:
+        if stake <= self.validator_min_stake:
             bt.logging.info(
                 f"Blacklisted validator {synapse.dendrite.hotkey} with insufficient stake: {stake}"
             )

--- a/llm_defender/core/miners/miner.py
+++ b/llm_defender/core/miners/miner.py
@@ -108,6 +108,21 @@ class PromptInjectionMiner(BaseNeuron):
         bt.logging.info(f"Miner is running with UID: {miner_uid}")
 
         return wallet, subtensor, metagraph, miner_uid
+    
+    def check_whitelist(self, hotkey):
+        """Checks if a given validator hotkey has been whitelisted."""
+
+        if isinstance(hotkey, bool) or not isinstance(hotkey, str):
+            return False
+        
+        whitelisted_hotkeys = [
+            "5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX" # sn14 mainnet test validator
+        ]
+
+        if hotkey in whitelisted_hotkeys:
+            return True
+
+        return False
 
     def blacklist(self, synapse: LLMDefenderProtocol) -> Tuple[bool, str]:
         """
@@ -125,6 +140,13 @@ class PromptInjectionMiner(BaseNeuron):
         This function must return [True, ""] for blacklisted requests
         and [False, ""] for non-blacklisted requests.
         """
+
+        # Check whitelisted hotkeys (queries should always be allowed)
+        if self.check_whitelist(hotkey=synapse.dendrite.hotkey):
+            bt.logging.info(
+                f"Accepted whitelisted hotkey: {synapse.dendrite.hotkey})"
+            )
+            return (False, f"Accepted whitelisted hotkey: {synapse.dendrite.hotkey}")
 
         # Blacklist entities that have not registered their hotkey
         if synapse.dendrite.hotkey not in self.metagraph.hotkeys:

--- a/llm_defender/core/miners/miner.py
+++ b/llm_defender/core/miners/miner.py
@@ -42,7 +42,7 @@ class PromptInjectionMiner(BaseNeuron):
         else:
             self.miner_set_weights = True
         
-        self.validator_min_stake = parser.validator_min_stake
+        self.validator_min_stake = args.validator_min_stake
 
         self.chromadb_client = VectorEngine().initialize()
 
@@ -116,7 +116,7 @@ class PromptInjectionMiner(BaseNeuron):
             return False
         
         whitelisted_hotkeys = [
-            "5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX" # sn14 dev team test validator
+            "5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX", # sn14 dev team test validator
         ]
 
         if hotkey in whitelisted_hotkeys:

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -14,12 +14,17 @@ import json
 from argparse import ArgumentParser
 from typing import Tuple
 from sys import getsizeof
-from os import path
+from datetime import datetime
+from os import path, rename
 from pathlib import Path
 import torch
 import bittensor as bt
 from llm_defender.base.neuron import BaseNeuron
-from llm_defender.base.utils import EnginePrompt, timeout_decorator, validate_miner_blacklist
+from llm_defender.base.utils import (
+    EnginePrompt,
+    timeout_decorator,
+    validate_miner_blacklist,
+)
 from llm_defender.base import mock_data
 from llm_defender.core.validators import penalty
 import requests
@@ -138,7 +143,7 @@ class PromptInjectionValidator(BaseNeuron):
 
         # Read command line arguments and perform actions based on them
         args = self._parse_args(parser=self.parser)
-        
+
         if args:
             if args.load_state:
                 self.load_state()
@@ -149,8 +154,7 @@ class PromptInjectionValidator(BaseNeuron):
                 self.max_targets = 256
         else:
             # Setup initial scoring weights
-            self.scores = torch.zeros_like(metagraph.S, dtype=torch.float32)
-            bt.logging.debug(f"Validation weights have been initialized: {self.scores}")
+            self.init_default_scores()
             self.max_targets = 256
 
         self.target_group = 0
@@ -159,18 +163,18 @@ class PromptInjectionValidator(BaseNeuron):
 
     def _parse_args(self, parser):
         return parser.parse_args()
-    
+
     def process_responses(
         self,
         processed_uids: torch.tensor,
         query: dict,
         responses: list,
-        synapse_uuid: str
+        synapse_uuid: str,
     ) -> list:
         """
         This function processes the responses received from the miners.
         """
-        
+
         if not synapse_uuid:
             synapse_uuid = None
 
@@ -195,16 +199,24 @@ class PromptInjectionValidator(BaseNeuron):
                 item in response.output for item in ["prompt", "confidence", "engines"]
             ):
                 old_score = copy.deepcopy(self.scores[processed_uids[i]])
-                bt.logging.trace(f'Setting weights for invalid response from UID: {processed_uids[i]}. Old score: {old_score}')
+                bt.logging.trace(
+                    f"Setting weights for invalid response from UID: {processed_uids[i]}. Old score: {old_score}"
+                )
                 self.scores[processed_uids[i]] = (
                     self.neuron_config.alpha * self.scores[processed_uids[i]]
                     + (1 - self.neuron_config.alpha) * 0.0
                 )
                 new_score = self.scores[processed_uids[i]]
-                bt.logging.trace(f'Setting weights for invalid response from UID: {processed_uids[i]}. New score: {new_score}')
+                bt.logging.trace(
+                    f"Setting weights for invalid response from UID: {processed_uids[i]}. New score: {new_score}"
+                )
                 response_score = (
                     distance_score
-                ) = speed_score = engine_score = distance_penalty_multiplier = general_penalty_multiplier= 0.0
+                ) = (
+                    speed_score
+                ) = (
+                    engine_score
+                ) = distance_penalty_multiplier = general_penalty_multiplier = 0.0
                 miner_response = {}
                 engine_data = []
                 responses_invalid_uids.append(processed_uids[i])
@@ -216,7 +228,7 @@ class PromptInjectionValidator(BaseNeuron):
                     speed_score,
                     engine_score,
                     distance_penalty_multiplier,
-                    general_penalty_multiplier
+                    general_penalty_multiplier,
                 ) = self.calculate_score(
                     response=response.output,
                     target=target,
@@ -295,7 +307,7 @@ class PromptInjectionValidator(BaseNeuron):
                     "engine_score": float(engine_score),
                     "distance_penalty_multiplier": float(distance_penalty_multiplier),
                     "general_penalty_multiplier": float(general_penalty_multiplier),
-                    "response_score": float(response_score)
+                    "response_score": float(response_score),
                 },
                 "weight_scores": {
                     "new": float(new_score),
@@ -415,7 +427,14 @@ class PromptInjectionValidator(BaseNeuron):
 
             return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 
-        return score, distance_score, speed_score, engine_score, distance_penalty_multiplier, general_penalty_multiplier
+        return (
+            score,
+            distance_score,
+            speed_score,
+            engine_score,
+            distance_penalty_multiplier,
+            general_penalty_multiplier,
+        )
 
     def apply_penalty(self, response, hotkey, prompt) -> tuple:
         """
@@ -492,10 +511,7 @@ class PromptInjectionValidator(BaseNeuron):
                 bt.logging.info(
                     f"Init default scores because of state and metagraph hotkey length mismatch. Expected: {len(self.metagraph.hotkeys)} had: {len(self.hotkeys)}"
                 )
-                self.scores = torch.zeros_like(self.metagraph.S, dtype=torch.float32)
-                bt.logging.info(
-                    f"Validation weights have been initialized: {self.scores}"
-                )
+                self.init_default_scores()
 
             self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
         else:
@@ -512,10 +528,19 @@ class PromptInjectionValidator(BaseNeuron):
         """Loads the miner state from a file"""
         state_path = f"{self.base_path}/miners.pickle"
         if path.exists(state_path):
-            with open(state_path, "rb") as pickle_file:
-                self.miner_responses = pickle.load(pickle_file)
+            try:
+                with open(state_path, "rb") as pickle_file:
+                    self.miner_responses = pickle.load(pickle_file)
 
-            bt.logging.debug("Loaded miner state from a file")
+                bt.logging.debug("Loaded miner state from a file")
+            except Exception as e:
+                bt.logging.error(f'Miner response data reset because a failure to read the miner response data, error: {e}')
+
+                # Rename the current miner state file if exception
+                # occurs and reset the default state
+                rename(state_path, f'{state_path}-{int(datetime.now().timestamp())}.autorecovery')
+                self.miner_responses = None
+
 
     def truncate_miner_state(self):
         """Truncates the local miner state"""
@@ -543,7 +568,7 @@ class PromptInjectionValidator(BaseNeuron):
                 "scores": self.scores,
                 "hotkeys": self.hotkeys,
                 "last_updated_block": self.last_updated_block,
-                "blacklisted_miner_hotkeys": self.blacklisted_miner_hotkeys
+                "blacklisted_miner_hotkeys": self.blacklisted_miner_hotkeys,
             },
             self.base_path + "/state.pt",
         )
@@ -551,6 +576,15 @@ class PromptInjectionValidator(BaseNeuron):
         bt.logging.debug(
             f"Saved the following state to a file: step: {self.step}, scores: {self.scores}, hotkeys: {self.hotkeys}, last_updated_block: {self.last_updated_block}, blacklisted_miner_hotkeys: {self.blacklisted_miner_hotkeys}"
         )
+
+    def init_default_scores(self) -> None:
+        """Validators without previous validation knowledge should start
+        with default score of 0.0 for each UID. The method can also be
+        used to reset the scores in case of an internal error"""
+
+        bt.logging.info("Initiating validator with default scores for each UID")
+        self.scores = torch.zeros_like(self.metagraph.S, dtype=torch.float32)
+        bt.logging.info(f"Validation weights have been initialized: {self.scores}")
 
     def load_state(self):
         """Loads the state of the validator from a file."""
@@ -570,11 +604,8 @@ class PromptInjectionValidator(BaseNeuron):
 
             bt.logging.info(f"Scores loaded from saved file: {self.scores}")
         else:
-            bt.logging.info("Validator state not found. Starting with default values.")
-            # Setup initial scoring weights
-            self.scores = torch.zeros_like(self.metagraph.S, dtype=torch.float32)
-            bt.logging.info(f"Validation weights have been initialized: {self.scores}")
-    
+            self.init_default_scores()
+
     @timeout_decorator(timeout=30)
     def sync_metagraph(self, metagraph, subtensor):
         """Syncs the metagraph"""
@@ -715,21 +746,26 @@ class PromptInjectionValidator(BaseNeuron):
                 if hotkey in self.metagraph.hotkeys:
                     blacklisted_uids.append(self.metagraph.hotkeys.index(hotkey))
                 else:
-                    bt.logging.trace(f'Blacklisted hotkey {hotkey} was not found from metagraph')
-            
-            bt.logging.debug(f'Blacklisted the following UIDs: {blacklisted_uids}')
-        
+                    bt.logging.trace(
+                        f"Blacklisted hotkey {hotkey} was not found from metagraph"
+                    )
+
+            bt.logging.debug(f"Blacklisted the following UIDs: {blacklisted_uids}")
+
         # Convert blacklisted UIDs to tensor
         blacklisted_uids_tensor = torch.tensor(
-            [uid not in blacklisted_uids for uid in self.metagraph.uids.tolist()],dtype=torch.bool
+            [uid not in blacklisted_uids for uid in self.metagraph.uids.tolist()],
+            dtype=torch.bool,
         )
 
-        bt.logging.trace(f'Blacklisted UIDs: {blacklisted_uids_tensor}')
+        bt.logging.trace(f"Blacklisted UIDs: {blacklisted_uids_tensor}")
 
         # Determine the UIDs to filter
-        uids_to_filter = torch.logical_not(~blacklisted_uids_tensor | ~invalid_uids | ~uids_with_stake)
+        uids_to_filter = torch.logical_not(
+            ~blacklisted_uids_tensor | ~invalid_uids | ~uids_with_stake
+        )
 
-        bt.logging.trace(f'UIDs to filter: {uids_to_filter}')
+        bt.logging.trace(f"UIDs to filter: {uids_to_filter}")
 
         # Define UIDs to query
         uids_to_query = [
@@ -749,26 +785,32 @@ class PromptInjectionValidator(BaseNeuron):
             self.metagraph.hotkeys.index(axon.hotkey) for axon in final_axons_to_filter
         ]
 
-        bt.logging.trace(f'Final axons to filter: {final_axons_to_filter}')
-        bt.logging.debug(f'Filtered UIDs: {uids_not_to_query}')
+        bt.logging.trace(f"Final axons to filter: {final_axons_to_filter}")
+        bt.logging.debug(f"Filtered UIDs: {uids_not_to_query}")
 
         # Reduce the number of simultaneous UIDs to query
         if self.max_targets < 256:
             start_idx = self.max_targets * self.target_group
-            end_idx = min(len(uids_to_query), self.max_targets * (self.target_group + 1))
+            end_idx = min(
+                len(uids_to_query), self.max_targets * (self.target_group + 1)
+            )
             if start_idx == end_idx:
-                return [],[]
+                return [], []
             if start_idx >= len(uids_to_query):
-                raise IndexError("Starting index for querying the miners is out-of-bounds")
-            
+                raise IndexError(
+                    "Starting index for querying the miners is out-of-bounds"
+                )
+
             if end_idx >= len(uids_to_query):
                 end_idx = len(uids_to_query)
                 self.target_group = 0
             else:
                 self.target_group += 1
-            
-            bt.logging.debug(f"List indices for UIDs to query starting from: '{start_idx}' ending with: '{end_idx}'")
-            uids_to_query = uids_to_query[start_idx:end_idx] 
+
+            bt.logging.debug(
+                f"List indices for UIDs to query starting from: '{start_idx}' ending with: '{end_idx}'"
+            )
+            uids_to_query = uids_to_query[start_idx:end_idx]
 
         list_of_uids = [
             self.metagraph.hotkeys.index(axon.hotkey) for axon in uids_to_query
@@ -776,8 +818,6 @@ class PromptInjectionValidator(BaseNeuron):
 
         list_of_hotkeys = [axon.hotkey for axon in uids_to_query]
 
-        bt.logging.trace(
-            f"Sending query to the following hotkeys: {list_of_hotkeys}"
-        )
+        bt.logging.trace(f"Sending query to the following hotkeys: {list_of_hotkeys}")
 
         return uids_to_query, list_of_uids, blacklisted_uids, uids_not_to_query

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -154,6 +154,9 @@ class PromptInjectionValidator(BaseNeuron):
             if self.load_validator_state:
                 self.load_state()
                 self.load_miner_state()
+            else:
+                self.init_default_scores()
+                
             if args.max_targets:
                 self.max_targets = args.max_targets
             else:

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -151,7 +151,7 @@ class PromptInjectionValidator(BaseNeuron):
             else:
                 self.load_validator_state = True
             
-            if args.load_validator_state:
+            if self.load_validator_state:
                 self.load_state()
                 self.load_miner_state()
             if args.max_targets:
@@ -610,6 +610,7 @@ class PromptInjectionValidator(BaseNeuron):
         self.step = 0
         self.last_updated_block = 0
         self.hotkeys = None
+        self.blacklisted_miner_hotkeys = None
     
     def load_state(self):
         """Loads the state of the validator from a file."""

--- a/llm_defender/neurons/miner.py
+++ b/llm_defender/neurons/miner.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--validator_min_stake",
         type=float,
-        default=5120.0,
+        default=20000.0,
         help="Determine the minimum stake the validator should have to accept requests",
     )
 

--- a/llm_defender/neurons/miner.py
+++ b/llm_defender/neurons/miner.py
@@ -139,6 +139,13 @@ if __name__ == "__main__":
         help="Determines if miner should set weights or not",
     )
 
+    parser.add_argument(
+        "--validator_min_stake",
+        type=float,
+        default=5120.0,
+        help="Determine the minimum stake the validator should have to accept requests",
+    )
+
     # Create a miner based on the Class definitions
     subnet_miner = PromptInjectionMiner(parser=parser)
 

--- a/llm_defender/neurons/validator.py
+++ b/llm_defender/neurons/validator.py
@@ -217,8 +217,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--load_state",
-        type=bool,
-        default=True,
+        type=str,
+        default="True",
         help="WARNING: Setting this value to False clears the old state.",
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = llm_defender
-version = 0.2.5
+version = 0.2.6
 author = ceterum1
 author_email = ceterum1@proton.me
 description = This project implements the llm-defender subnet for Bittensor

--- a/tests/miner/neuron.py
+++ b/tests/miner/neuron.py
@@ -1,0 +1,57 @@
+from llm_defender.core.miners import miner
+from argparse import ArgumentParser
+import pytest
+import uuid
+from unittest.mock import MagicMock
+from pathlib import Path
+import bittensor as bt
+
+class TestMiner:
+
+    @classmethod
+    def setup_class(cls):
+
+        cls.wallet = MagicMock(spec=bt.wallet)
+        cls.wallet.name = "test-wallet"
+        cls.wallet.hotkey = "rzmejftlbjtdukjfjxygklcccmovxrra"
+
+        cls.tmp_dir = Path(f"/tmp/pytest-{uuid.uuid4()}")
+        cls.tmp_dir.mkdir(parents=True, exist_ok=True)
+
+        cls.netuid = 38
+        
+    @pytest.fixture
+    def pytest_miner(self):
+        # Initialize validator with valid configuration
+        parser = ArgumentParser()
+        parser.add_argument(
+            "--logging.logging_dir", type=str, default=str(self.tmp_dir)
+        )
+        parser.add_argument("--wallet.name", type=str, default=self.wallet.name)
+        parser.add_argument("--wallet.hotkey", type=str, default=self.wallet.hotkey)
+        parser.add_argument("--wallet.path", type=str, default=str(self.tmp_dir))
+        parser.add_argument("--netuid", type=int, default=self.netuid)
+        parser.add_argument(
+            "--subtensor.network", type=str, default="test"
+        )
+
+        parser.add_argument(
+            "--miner_set_weights",
+            type=str,
+            default="True",
+            help="Determines if miner should set weights or not",
+        )
+
+        parser.add_argument(
+            "--validator_min_stake",
+            type=float,
+            default=5120.0,
+            help="Determine the minimum stake the validator should have to accept requests",
+        )
+
+        pytest_miner = miner.PromptInjectionMiner(parser=parser)
+
+        yield pytest_miner
+
+    def test_whitelist(self, pytest_miner):
+        assert pytest_miner.check_whitelist(hotkey="5G4gJgvAJCRS6ReaH9QxTCvXAuc4ho5fuobR7CMcHs4PRbbX") is True


### PR DESCRIPTION
* Code adjustments to support pydantic==2.5.2 which comes as a requirement from Bittensor==7.0.0
* Added safeguards around the validator state loading to ensure the validator does not fail to start if the state files are invalid and/or otherwise corrupted
* Fixed an issue with the argument parsing for the validator state loading
* Added default stake limit of 20000.0 TAO
* Added whitelist for pre-determined low-stake validators
* Submet module version upgrade to 0.2.6